### PR TITLE
fix: code and score can be 0

### DIFF
--- a/src/rabbitmq/jobqueue.ts
+++ b/src/rabbitmq/jobqueue.ts
@@ -65,7 +65,7 @@ amqp.connect(`amqp://${config.AMQP.USER}:${config.AMQP.PASS}@${config.AMQP.HOST}
         if (payload.testcases) {
           eventName = 'submit_result'
         }
-        else if (payload.code && payload.score) {
+        else if (payload.hasOwnProperty('code') && payload.hasOwnProperty('score')) {
           eventName = 'project_result'
         }
         else {


### PR DESCRIPTION
In the response from `judge-taskmaster`, `code` and `score` can be zero. 
This would've failed for such cases